### PR TITLE
Update archive_group.py

### DIFF
--- a/archive_group.py
+++ b/archive_group.py
@@ -97,7 +97,7 @@ def archive_message(groupName, msgNumber, depth=0):
 		#some other problem, perhaps being refused access by Yahoo?
 		#retry for a max of 3 times anyway
 		if depth < 3:
-			print "Cannot get message " + str(msgNumber) + ", attempt " + str(depth+1) + " of 3"
+			print "Cannot get message " + str(msgNumber) + ", attempt " + str(depth+1) + " of 3 due to HTTP status code " + str(resp.status_code)
 			time.sleep(0.1)
 			archive_message(groupName,msgNumber,depth+1)
 		else:


### PR DESCRIPTION
Added HTTP status code to error message displayed when the archiver fails after three attempts.

I hope it's okay to submit this (and that I'm doing it the right way).  I'm new to open source and participating in Hacktoberfest.  

I used your fantastic tool this summer and added this bit to troubleshoot some issues I was having archiving messages.  Hundreds of failures on specific blocks of messages turned out to be 404 errors.  