### PR TITLE
Escape <, >, & and wrap <pre> text.

### DIFF
--- a/make_Yearly_Text_Archive_html.py
+++ b/make_Yearly_Text_Archive_html.py
@@ -29,6 +29,7 @@ import os
 import sys
 from datetime import datetime
 from natsort import natsorted, ns
+import cgi
 
 #To avoid Unicode Issues
 reload(sys)
@@ -37,6 +38,8 @@ sys.setdefaultencoding('utf-8')
 def archiveYahooMessage(file, archiveFile, messageYear, format):
      try:
           f = open(archiveFile, 'a')
+          if f.tell() == 0:
+               f.write("<style>pre {white-space: pre-wrap;}</style>\n");
           f.write(loadYahooMessage(file, format))
           f.close()
           print 'Yahoo Message: ' + file + ' archived to: archive-' + str(messageYear) + '.html'
@@ -58,14 +61,14 @@ def loadYahooMessage(file, format):
     message = email.message_from_string(emailMessageString)
     messageBody = getEmailBody(message)
     
-    messageText = '-----------------------------------------------------------------------------------<br>'
-    messageText += 'Post ID:' + str(emailMessageID) + '<br>'
-    messageText += 'Sender:' + emailMessageSender + '<br>'
-    messageText += 'Post Date/Time:' + emailMessageDateTime + '<br>'
-    messageText += 'Subject:' + emailMessageSubject + '<br>'
-    messageText += 'Message:' + '<br><br>'
+    messageText = '-----------------------------------------------------------------------------------<br>' + "\n"
+    messageText += 'Post ID:' + str(emailMessageID) + '<br>' + "\n"
+    messageText += 'Sender:' + cgi.escape(emailMessageSender) + '<br>' + "\n"
+    messageText += 'Post Date/Time:' + cgi.escape(emailMessageDateTime) + '<br>' + "\n"
+    messageText += 'Subject:' + cgi.escape(emailMessageSubject) + '<br>' + "\n"
+    messageText += 'Message:' + '<br><br>' + "\n"
     messageText += messageBody
-    messageText += '<br><br><br><br><br>'
+    messageText += '<br><br><br><br><br>' + "\n"
     return messageText
     
 def getYahooMessageYear(file):
@@ -88,7 +91,7 @@ def getEmailBody(message):
             # skip any text/plain (txt) attachments
             if ctype == 'text/plain' and 'attachment' not in cdispo:
                 body += '<pre>'
-                body += part.get_payload(decode=True)  # decode
+                body += cgi.escape(part.get_payload(decode=True))  # decode
                 body += '</pre>'
                 break
     # not multipart - i.e. plain text, no attachments, keeping fingers crossed
@@ -96,9 +99,10 @@ def getEmailBody(message):
         ctype = message.get_content_type()
         if ctype != 'text/html':
              body += '<pre>'
-        body += message.get_payload(decode=True)
-        if ctype != 'text/html':
+             body += cgi.escape(message.get_payload(decode=True))
              body += '</pre>'
+        else:
+             body += message.get_payload(decode=True)
     return body
 
 ## This is where the script starts


### PR DESCRIPTION
The yearly HTML output wasn't escaping <, > and & which mostly meant that the "Sender" field would appear empty.  I also added a <STYLE> tag to add word wrapping to <PRE> elements for e-mail messages which long lines.

And tossed in a few newlines to make the HTML output more human readable.